### PR TITLE
Modify BSE to support asterisk in HarvestReductionParameters

### DIFF
--- a/src/HarvestEffects.cs
+++ b/src/HarvestEffects.cs
@@ -206,12 +206,14 @@ namespace Landis.Extension.Succession.Biomass
 
             prescriptionName = prescriptionName.Trim();
 
+            // Find prescription from input (HarvestReductionsTable)
             var prescription = PlugIn.Parameters.HarvestReductionsTable.FirstOrDefault(p =>
                 prescriptionName == p.PrescriptionName.Trim());
 
             if (prescription != null)
                 return prescription;
 
+            // If prescription with specific name is not found trying to find relevant template
             var templates = PlugIn.Parameters.HarvestReductionsTable.Where(p => p.PrescriptionName.Contains("*"));
 
             var resultCharNumbers = 0;
@@ -219,13 +221,15 @@ namespace Landis.Extension.Succession.Biomass
             foreach (var template in templates)
             {
                 int charNumbers = 0;
-
+                
+                // Calculate the number of characters matching the template
                 for (int i = 0; i < template.PrescriptionName.Trim().Length; i++)
                 {
                     if (prescriptionName.Length > i && prescriptionName[i] == template.PrescriptionName[i])
                         charNumbers++;
                 }
 
+                // Select template with the largest number of matches in the name 
                 if (charNumbers >= resultCharNumbers)
                 {
                     resultCharNumbers = charNumbers;


### PR DESCRIPTION
SHE needs to create new prescriptions in BHE. This might lead to a problem that this prescription is not defined in BSE.

To solve the problem, we should allow using wildcards in BSE at the end of the name.

Examples of possible names:

MM*

MM1_DO*

* 

If there are several lines matching the search, the one with more specific characters should be used (MM1_DO* for the case above).